### PR TITLE
Add org-wide FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,3 @@
+github: rladies
+custom:
+  - "https://www.paypal.com/donate/?hosted_button_id=VB4EK67MJ373E"


### PR DESCRIPTION
## Summary
- Add `FUNDING.yml` with GitHub Sponsors and PayPal donation link
- Applies org-wide to all R-Ladies repos that don't have their own FUNDING.yml

## Test plan
- [ ] Verify "Sponsor" button appears on R-Ladies repos after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)